### PR TITLE
Support for having single quotes in variables

### DIFF
--- a/tests/test_tulip.py
+++ b/tests/test_tulip.py
@@ -57,7 +57,9 @@ def test_parsing(mocker):
     mocker.patch("kubernetes.config.new_client_from_config")
 
     t = Tulip("conf", "my_namespace", {}, "fixtures")
-    out = t.prepare(Path("./tests/fixtures/parse.yaml"), {".test.var": 1234})
+    out = t.prepare(
+        Path("./tests/fixtures/parse.yaml"), {".test.var": "foo'bar"}
+    )
 
     assert ".test.var" not in out
-    assert "1234" in out
+    assert "foo''bar" in out

--- a/tulips/tulip.py
+++ b/tulips/tulip.py
@@ -118,6 +118,8 @@ class Tulip:
             val = maps[name]
             if name.startswith("@"):
                 val = val()
-            return str(val)
+            val = str(val)
+            val = val.replace("'", "''")  # yaml-escape single quote
+            return val
 
         return re.sub(pattern, replace, text)


### PR DESCRIPTION
Without this, the output of `prepare` is not valid YAML syntax.

Refs https://github.com/niteoweb/woocart/issues/980